### PR TITLE
Refactor: main페이지의 SortButtons 리팩토링 및 target 추가

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import './globals.css';
 import { Inter } from 'next/font/google';
 import { MainStoreProvider } from '@/providers/main-store-provider';
+import Header from '@/components/common/Header';
 
 export const metadata: Metadata = {
   title: '에이택 어드민',
@@ -20,7 +21,8 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko" className={inter.className}>
-      <body className="flex flex-col items-center w-full my-120">
+      <body className="flex flex-col items-center gap-60 w-full my-120">
+        <Header />
         <MainStoreProvider>{children}</MainStoreProvider>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,18 +2,20 @@ import Pagination from '@/components/common/Pagination';
 import ListSection from '@/components/main/ListSection';
 import SortButtons from '@/components/main/SortButtons';
 import { getData } from '@/services/main';
+import { STATE_BUTTONS, TARGET_BUTTONS } from '@/utils/constants';
 
-export default async function Home() {
+export default async function MainPage() {
   const response = await getData({ target: 'all', state: 'all' });
 
   return (
-    <div className="w-1384 flex flex-col gap-74">
-      <header className="text-36 font-semibold text-black">A;tag Admin Page</header>
-      <main className="flex flex-col gap-61">
-        <SortButtons />
-        <ListSection data={response.data} />
-        <Pagination initTotalPages={response.totalPages} />
-      </main>
-    </div>
+    <main className="w-1400 flex flex-col gap-60">
+      <section className="flex items-center gap-60">
+        <SortButtons type="state" buttons={STATE_BUTTONS} />
+        <hr className="h-38 border-1" />
+        <SortButtons type="target" buttons={TARGET_BUTTONS} />
+      </section>
+      <ListSection data={response.data} />
+      <Pagination initTotalPages={response.totalPages} />
+    </main>
   );
 }

--- a/src/app/post/[postId]/layout.tsx
+++ b/src/app/post/[postId]/layout.tsx
@@ -1,0 +1,7 @@
+export default function PostIdLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return <main className="w-1384">{children}</main>;
+}

--- a/src/app/post/[postId]/page.tsx
+++ b/src/app/post/[postId]/page.tsx
@@ -1,0 +1,3 @@
+export default function PostIdPage() {
+  return <div>포스트 아이디 페이지</div>;
+}

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,0 +1,17 @@
+interface ButtonProps {
+  text: string;
+  clicked?: boolean;
+  handleClick: () => void;
+}
+
+export default function Button({ text, clicked = false, handleClick }: ButtonProps) {
+  return (
+    <button
+      onClick={handleClick}
+      className={`flex items-center justify-center rounded-lg w-108 h-40 text-18 ${
+        clicked ? 'bg-gray-400 text-white' : 'bg-gray-100'
+      }`}>
+      {text}
+    </button>
+  );
+}

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,0 +1,3 @@
+export default function Header() {
+  return <header className="w-1400 text-36 font-semibold text-black">A;tag Admin Page</header>;
+}

--- a/src/components/main/TargetButtons.tsx
+++ b/src/components/main/TargetButtons.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useMainStore } from '@/providers/main-store-provider';
+import { getData } from '@/services/main';
+import { TARGET_BUTTONS } from '@/utils/constants';
+import { useCallback, useEffect } from 'react';
+import SortButton from '../common/Button';
+import { TargetType } from '@/services/main/schema';
+
+export default function TargetButtons() {
+  const { target, setTarget, state, setDatas, setPage, setTotalPages } = useMainStore((state) => state);
+
+  const fetchPageData = useCallback(async () => {
+    const response = await getData({ target: target, state: state });
+
+    setDatas(response.data);
+    setTotalPages(response.totalPages);
+  }, [setDatas, setTotalPages, state, target]);
+
+  const handleChangeState = (targetValue: TargetType) => {
+    setTarget(targetValue);
+    setPage(1);
+  };
+
+  useEffect(() => {
+    fetchPageData();
+  }, [target, fetchPageData]);
+
+  return (
+    <div className="flex items-center gap-40">
+      {TARGET_BUTTONS.map((targetItem) => (
+        <SortButton
+          key={targetItem.value}
+          text={targetItem.text}
+          clicked={targetItem.value === state}
+          handleClick={() => handleChangeState(targetItem.value as TargetType)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/services/main/index.ts
+++ b/src/services/main/index.ts
@@ -9,7 +9,6 @@ export async function getData(params: getDataParamsType) {
 
   requestParams.set('target', params.target);
   requestParams.set('state', params.state);
-  requestParams.set('limit', '14');
   requestParams.set('limit', params.limit || MAIN_DATA_LIMIT);
   requestParams.set('page', params.page || '1');
 

--- a/src/stores/main-store.ts
+++ b/src/stores/main-store.ts
@@ -1,9 +1,10 @@
 import { createStore } from 'zustand/vanilla';
-import { DataType } from '@/services/main/schema';
+import { DataType, StateType, TargetType } from '@/services/main/schema';
 
 export type MainStateType = {
   datas: DataType[];
-  state: string;
+  target: TargetType;
+  state: StateType;
   page: number;
   totalPages: number;
   search: string;
@@ -11,7 +12,8 @@ export type MainStateType = {
 
 export type MainActionsType = {
   setDatas: (datas: DataType[]) => void;
-  setState: (state: string) => void;
+  setTarget: (target: TargetType) => void;
+  setState: (state: StateType) => void;
   setPage: (page: number) => void;
   setTotalPages: (totalPages: number) => void;
   setSearch: (search: string) => void;
@@ -21,6 +23,7 @@ export type CreateMainStoreType = MainStateType & MainActionsType;
 
 export const defaultData: MainStateType = {
   datas: [],
+  target: 'all',
   state: 'all',
   page: 1,
   totalPages: 1,
@@ -31,7 +34,8 @@ export const createMainStore = (initState: MainStateType = defaultData) => {
   return createStore<CreateMainStoreType>()((set) => ({
     ...initState,
     setDatas: (datas: DataType[]) => set(() => ({ datas })),
-    setState: (state: string) => set(() => ({ state })),
+    setTarget: (target: TargetType) => set(() => ({ target })),
+    setState: (state: StateType) => set(() => ({ state })),
     setPage: (page: number) => set(() => ({ page })),
     setTotalPages: (totalPages: number) => set(() => ({ totalPages })),
     setSearch: (search: string) => set(() => ({ search })),

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,7 +1,16 @@
-export const SORT_BUTTONS = [
-  { id: 'all', text: '전체' },
-  { id: 'pending', text: '진행중' },
-  { id: 'done', text: '완료' },
+import { StateType, TargetType } from '@/services/main/schema';
+
+export const STATE_BUTTONS: Array<{ value: StateType; text: string }> = [
+  { value: 'all', text: '전체' },
+  { value: 'pending', text: '진행중' },
+  { value: 'done', text: '완료' },
+];
+
+export const TARGET_BUTTONS: Array<{ value: TargetType; text: string }> = [
+  { value: 'all', text: '전체' },
+  { value: 'ai', text: 'AI 생성' },
+  { value: 'inspect', text: '해설진 검수' },
+  { value: 'comment', text: '해설진 작성' },
 ];
 
 export const MAIN_DATA_LIMIT = '14';


### PR DESCRIPTION
1. / 메인페이지의 상단 SortButtons에 target이 추가되면서 state와 target 둘다에 재활용할 수 있게 SortButtons를 리팩토링하였습니다. 


![refactore](https://github.com/Si-gongan/atag-admin-frontend/assets/131663155/4b8532f9-61b3-4baf-bffe-241ab0ed111d)
