### PR TITLE
Feat: /post/:postId에서 work 선택, 전체선택 구현

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
-import Pagination from '@/components/common/Pagination';
 import ListSection from '@/components/main/ListSection';
+import MainPagination from '@/components/main/MainPagination';
 import SortButtons from '@/components/main/SortButtons';
 import { getData } from '@/services/main';
 import { STATE_BUTTONS, TARGET_BUTTONS } from '@/utils/constants';
@@ -15,7 +15,7 @@ export default async function MainPage() {
         <SortButtons type="target" buttons={TARGET_BUTTONS} />
       </section>
       <ListSection data={response.data} />
-      <Pagination initTotalPages={response.totalPages} />
+      <MainPagination initTotalPages={response.totalPages} />
     </main>
   );
 }

--- a/src/app/post/[postId]/layout.tsx
+++ b/src/app/post/[postId]/layout.tsx
@@ -1,0 +1,9 @@
+import { PostStoreProvider } from '@/providers/post-store-provider';
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return <PostStoreProvider>{children}</PostStoreProvider>;
+}

--- a/src/app/post/[postId]/page.tsx
+++ b/src/app/post/[postId]/page.tsx
@@ -1,8 +1,7 @@
-import Pagination from '@/components/common/Pagination';
 import DelExportButtons from '@/components/post/DelExportButtons';
 import PostListSection from '@/components/post/PostListSection';
+import PostPagination from '@/components/post/PostPagination';
 import PostTitle from '@/components/post/PostTitle';
-import { getPostDetail } from '@/services/post';
 
 interface PostIdPageProps {
   params: { postId: string };
@@ -10,16 +9,13 @@ interface PostIdPageProps {
 
 export default async function PostIdPage({ params }: PostIdPageProps) {
   const { postId } = params;
-  const initPostDetail = await getPostDetail(postId);
-  const { title, detail = null, works } = initPostDetail;
-  const totalPages = Math.floor(works.length / 9) + 1;
 
   return (
     <main className="w-1400 flex flex-col gap-43">
-      <PostTitle title={title} detail={detail} />
+      <PostTitle postId={postId} />
       <DelExportButtons />
-      <PostListSection works={works} />
-      <Pagination initTotalPages={totalPages} />
+      <PostListSection />
+      <PostPagination />
     </main>
   );
 }

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,23 +1,4 @@
-// interface ButtonProps {
-//   text: string;
-//   clicked?: boolean;
-//   handleClick: () => void;
-// }
-
-import Image from 'next/image';
 import CheckBox from './CheckBox';
-
-// export default function Button({ text, clicked = false, handleClick }: ButtonProps) {
-//   return (
-//     <button
-//       onClick={handleClick}
-//       className={`flex items-center justify-center rounded-lg w-108 h-40 text-18 ${
-//         clicked ? 'bg-gray-400 text-white' : 'bg-gray-100'
-//       }`}>
-//       {text}
-//     </button>
-//   );
-// }
 
 interface ButtonProps {
   text: string;

--- a/src/components/common/CheckBox.tsx
+++ b/src/components/common/CheckBox.tsx
@@ -2,11 +2,14 @@ import Image from 'next/image';
 
 interface CheckBoxProps {
   clicked: boolean;
+  onClick?: () => void;
 }
 
-export default function CheckBox({ clicked }: CheckBoxProps) {
+export default function CheckBox({ clicked, onClick }: CheckBoxProps) {
   return (
-    <div className="flex items-center justify-center w-23 h-23 bg-white border-1 border-gray-400 rounded">
+    <div
+      className="flex items-center justify-center w-23 h-23 bg-white border-1 border-gray-400 rounded"
+      onClick={onClick}>
       {clicked && <Image src="/images/check.svg" alt="체크 아이콘" width={14} height={14} />}
     </div>
   );

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -1,30 +1,20 @@
 'use client';
 
-import { useMainStore } from '@/providers/main-store-provider';
-import { getData } from '@/services/main';
-import { StateType } from '@/services/main/schema';
 import Image from 'next/image';
-import { useCallback, useEffect } from 'react';
 
 interface PaginationProps {
-  initTotalPages: number;
+  page: number;
+  setPage: (page: number) => void;
+  totalPages: number;
 }
 
-export default function Pagination({ initTotalPages }: PaginationProps) {
-  const { page, setPage, totalPages, setTotalPages, setDatas, state } = useMainStore((state) => state);
-
+export default function Pagination({ page, setPage, totalPages }: PaginationProps) {
   const startPage = Math.floor((page - 1) / 10) * 10 + 1;
   const endPage = Math.min(startPage + 9, totalPages);
   const prevPage = page > 10;
   const nextPage = startPage * 10 < totalPages;
 
   const pageNumbers = Array.from({ length: endPage - startPage + 1 }, (_, index) => startPage + index);
-
-  const fetchPageData = useCallback(async () => {
-    const response = await getData({ target: 'all', state: state as StateType, page: String(page) });
-
-    setDatas(response.data);
-  }, [state, setDatas, page]);
 
   const handlePrev = () => {
     setPage(startPage - 1);
@@ -37,14 +27,6 @@ export default function Pagination({ initTotalPages }: PaginationProps) {
   const handleNext = () => {
     setPage(endPage + 1);
   };
-
-  useEffect(() => {
-    setTotalPages(initTotalPages);
-  }, [initTotalPages, setTotalPages]);
-
-  useEffect(() => {
-    fetchPageData();
-  }, [page, fetchPageData]);
 
   return (
     <div className="flex justify-between items-center w-full">

--- a/src/components/main/MainPagination.tsx
+++ b/src/components/main/MainPagination.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useMainStore } from '@/providers/main-store-provider';
+import { getData } from '@/services/main';
+import { StateType } from '@/services/main/schema';
+import { useCallback, useEffect } from 'react';
+import Pagination from '../common/Pagination';
+
+interface MainPaginationProps {
+  initTotalPages: number;
+}
+
+export default function MainPagination({ initTotalPages }: MainPaginationProps) {
+  const { page, setPage, totalPages, setTotalPages, setDatas, state } = useMainStore((state) => state);
+
+  const fetchPageData = useCallback(async () => {
+    const response = await getData({ target: 'all', state: state as StateType, page: String(page) });
+
+    setDatas(response.data);
+  }, [state, setDatas, page]);
+
+  useEffect(() => {
+    setTotalPages(initTotalPages);
+  }, [initTotalPages, setTotalPages]);
+
+  useEffect(() => {
+    fetchPageData();
+  }, [page, fetchPageData]);
+
+  return <Pagination page={page} setPage={setPage} totalPages={totalPages} />;
+}

--- a/src/components/post/DelExportButtons.tsx
+++ b/src/components/post/DelExportButtons.tsx
@@ -2,12 +2,20 @@
 
 import { useState } from 'react';
 import Button from '../common/Button';
+import { usePostStore } from '@/providers/post-store-provider';
 
 export default function DelExportButtons() {
-  const [selectedAll, setSelectedAll] = useState(false);
+  const [clickedAll, setClickedAll] = useState(false);
+
+  const { selectAllCurrentPageWorks } = usePostStore((state) => ({
+    post: state.post,
+    selectedWorks: state.selectedWorks,
+    selectAllCurrentPageWorks: state.selectAllCurrentPageWorks,
+  }));
 
   const handleSelectAll = () => {
-    setSelectedAll((prev) => !prev);
+    selectAllCurrentPageWorks(clickedAll);
+    setClickedAll((prev) => !prev);
   };
 
   const handleDelete = () => {
@@ -20,7 +28,7 @@ export default function DelExportButtons() {
 
   return (
     <div className="flex items-center gap-30">
-      <Button text="전체선택" size="large" clicked={selectedAll} selectable={true} handleClick={handleSelectAll} />
+      <Button text="전체선택" size="large" clicked={clickedAll} selectable={true} handleClick={handleSelectAll} />
       <Button text="삭제" size="large" handleClick={handleDelete} />
       <Button text="내보내기" size="large" handleClick={handleExport} />
     </div>

--- a/src/components/post/PostItem.tsx
+++ b/src/components/post/PostItem.tsx
@@ -1,16 +1,19 @@
 'use client';
 
-import { WorksType } from '@/services/post/schema';
+import { PostTargetType, WorksType } from '@/services/post/schema';
 import CheckBox from '../common/CheckBox';
 import Image from 'next/image';
 import Button from '../common/Button';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { usePostStore } from '@/providers/post-store-provider';
 
 interface PostItemProps {
   work: WorksType;
+  target: PostTargetType;
 }
 
-export default function PostItem({ work }: PostItemProps) {
+export default function PostItem({ work, target }: PostItemProps) {
+  const [checked, setChecked] = useState(false);
   const [editModalOpen, setEditModalOpen] = useState<boolean>(false);
 
   const thumbnail =
@@ -18,9 +21,28 @@ export default function PostItem({ work }: PostItemProps) {
       ? work.image
       : '/images/default-thumbnail.png';
 
+  const { selectedWorks, addSelectedWork, deleteSelectedWork } = usePostStore((state) => ({
+    selectedWorks: state.selectedWorks,
+    addSelectedWork: state.addSelectedWork,
+    deleteSelectedWork: state.deleteSelectedWork,
+  }));
+
+  const handleClick = () => {
+    const findSelectedWork = selectedWorks.find((selectedWork) => selectedWork.id === work.id);
+
+    if (!checked && !findSelectedWork) {
+      addSelectedWork(work);
+    } else deleteSelectedWork(work.id);
+  };
+
+  useEffect(() => {
+    const isWorkSelected = selectedWorks.some((selectedWork) => selectedWork.id === work.id);
+    setChecked(isWorkSelected);
+  }, [selectedWorks, work.id]);
+
   return (
     <section className="flex gap-12 items-center w-436 h-142 px-10 bg-gray-100 rounded-10">
-      <CheckBox clicked={false} />
+      <CheckBox clicked={checked} onClick={handleClick} />
       <div className="relative w-77 h-74">
         <Image
           src={thumbnail}
@@ -32,8 +54,8 @@ export default function PostItem({ work }: PostItemProps) {
         />
       </div>
       <div className="flex flex-col items-end">
-        <p className="w-292 h-48 text-13 leading-16 line-clamp-3">{work.answer}</p>
-        <Button text="수정" size="small" handleClick={() => setEditModalOpen(true)} />
+        <p className="w-292 h-48 text-13 leading-16 line-clamp-3">{work.answer ? work.answer : '없음'}</p>
+        {target !== 'ai' && <Button text="수정" size="small" handleClick={() => setEditModalOpen(true)} />}
       </div>
     </section>
   );

--- a/src/components/post/PostListSection.tsx
+++ b/src/components/post/PostListSection.tsx
@@ -1,22 +1,21 @@
-import { WorksType } from '@/services/post/schema';
+'use client';
+
+import { POST_LIST_PAGE_LIMIT } from '@/utils/constants';
 import PostItem from './PostItem';
+import { usePostStore } from '@/providers/post-store-provider';
 
-interface PostListSectionProps {
-  works: WorksType[];
-}
+export default function PostListSection() {
+  const { post, page } = usePostStore((state) => state);
 
-export default function PostListSection({ works }: PostListSectionProps) {
-  const page = 1;
-  const startIndex = (page - 1) * 9 + 1;
-  const indexArray = Array.from({ length: 9 }, (_, index) => startIndex + index);
+  const startIndex = (page - 1) * POST_LIST_PAGE_LIMIT;
+  const indexArray = Array.from({ length: POST_LIST_PAGE_LIMIT }, (_, index) => startIndex + index);
 
   return (
     <section className="flex flex-wrap gap-x-46 gap-y-44">
-      {indexArray.map((index) => works[index] && <PostItem key={works[index].id} work={works[index]} />)}
-      {/* {works.map((work, index) => (
-
-        <PostItem key={work.id} work={work} />
-      ))} */}
+      {indexArray.map(
+        (index) =>
+          post?.works[index] && <PostItem key={post?.works[index].id} work={post?.works[index]} target={post?.target} />
+      )}
     </section>
   );
 }

--- a/src/components/post/PostPagination.tsx
+++ b/src/components/post/PostPagination.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { usePostStore } from '@/providers/post-store-provider';
+import Pagination from '../common/Pagination';
+
+export default function PostPagination() {
+  const { page, setPage, post } = usePostStore((state) => state);
+
+  const totalPages = post ? Math.ceil(post.works.length / 9) : 1;
+
+  return <Pagination page={page} setPage={setPage} totalPages={totalPages} />;
+}

--- a/src/components/post/PostTitle.tsx
+++ b/src/components/post/PostTitle.tsx
@@ -1,16 +1,27 @@
+'use client';
+
+import { usePostStore } from '@/providers/post-store-provider';
+import { useEffect } from 'react';
+
 interface PostTitleProps {
-  title: string;
-  detail: string | null;
+  postId: string;
 }
 
-export default function PostTitle({ title, detail }: PostTitleProps) {
+export default function PostTitle({ postId }: PostTitleProps) {
+  const { setPostId, fetchPost, post } = usePostStore((state) => state);
+
+  useEffect(() => {
+    setPostId(postId);
+    fetchPost(postId);
+  }, [postId, setPostId, fetchPost]);
+
   return (
     <div className="flex flex-col gap-25">
-      <h2 className="text-36">{title}</h2>
-      {detail && (
+      <h2 className="text-36">{post?.title}</h2>
+      {post?.detail && (
         <div className="flex flex-col gap-14 w-full text-24">
           해설진 작성 세부 요청서
-          <p className="flex p-20 bg-gray-100 text-24">{detail}</p>
+          <p className="flex p-20 bg-gray-100 text-24">{post?.detail}</p>
         </div>
       )}
     </div>

--- a/src/lib/fetcher.ts
+++ b/src/lib/fetcher.ts
@@ -13,6 +13,7 @@ export async function fetcher(endPoint: string, method: string, options?: any) {
       ...defaultHeaders,
       ...options?.headers,
     },
+    cache: 'no-store',
     ...options,
   };
 

--- a/src/providers/main-store-provider.tsx
+++ b/src/providers/main-store-provider.tsx
@@ -25,7 +25,7 @@ export const useMainStore = <T,>(selector: (store: CreateMainStoreType) => T): T
   const mainStoreContext = useContext(MainStoreContext);
 
   if (!mainStoreContext) {
-    throw new Error(`useMainStore은 반드시 MainStoreProvider 안에서 사용해야 해요!`);
+    throw new Error('useMainStore은 반드시 MainStoreProvider 안에서 사용해야 해요!');
   }
 
   return useStore(mainStoreContext, selector);

--- a/src/providers/post-store-provider.tsx
+++ b/src/providers/post-store-provider.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { CreatePostStoreType, createPostStore } from '@/stores/post-store';
+import { ReactNode, createContext, useContext, useRef } from 'react';
+import { useStore } from 'zustand';
+
+export type PostStoreApi = ReturnType<typeof createPostStore>;
+
+export const PostStoreContext = createContext<PostStoreApi | undefined>(undefined);
+
+export interface PostStoreProviderProps {
+  children: ReactNode;
+}
+
+export const PostStoreProvider = ({ children }: PostStoreProviderProps) => {
+  const storeRef = useRef<PostStoreApi>();
+  if (!storeRef.current) {
+    storeRef.current = createPostStore();
+  }
+
+  return <PostStoreContext.Provider value={storeRef.current}>{children}</PostStoreContext.Provider>;
+};
+
+export const usePostStore = <T,>(selector: (store: CreatePostStoreType) => T): T => {
+  const postStoreContext = useContext(PostStoreContext);
+
+  if (!postStoreContext) {
+    throw new Error('usePostStore은 반드시 PostStoreProvider 안에서 사용해야 해요!');
+  }
+
+  return useStore(postStoreContext, selector);
+};

--- a/src/stores/post-store.ts
+++ b/src/stores/post-store.ts
@@ -1,23 +1,70 @@
-import { getPostDetailType } from '@/services/post/schema';
+import { getPostDetail } from '@/services/post';
+import { WorksType, getPostDetailType } from '@/services/post/schema';
+import { POST_LIST_PAGE_LIMIT } from '@/utils/constants';
 import { createStore } from 'zustand';
 
 export type PostStateType = {
+  postId: string;
   post: getPostDetailType | null;
+  selectedWorks: WorksType[];
+  page: number;
 };
 
 export type PostActionsType = {
-  setPost: (post: getPostDetailType) => void;
+  setPostId: (postId: string) => void;
+  fetchPost: (postId: string) => Promise<void>;
+  addSelectedWork: (newWork: WorksType) => void;
+  deleteSelectedWork: (workId: string) => void;
+  selectAllCurrentPageWorks: (clickedAll: boolean) => void;
+  setPage: (page: number) => void;
 };
 
 export type CreatePostStoreType = PostStateType & PostActionsType;
 
 export const defaultPost: PostStateType = {
+  postId: '',
   post: null,
+  selectedWorks: [],
+  page: 1,
 };
 
 export const createPostStore = (initState: PostStateType = defaultPost) => {
-  return createStore<CreatePostStoreType>()((set) => ({
+  return createStore<CreatePostStoreType>()((set, get) => ({
     ...initState,
-    setPost: (post: getPostDetailType) => set(() => ({ post })),
+    setPostId: (postId: string) => set(() => ({ postId })),
+    fetchPost: async (postId: string) => {
+      const response = await getPostDetail(postId);
+      set({ post: response });
+    },
+    addSelectedWork: (newWork: WorksType) =>
+      set((state) => ({
+        selectedWorks: [...state.selectedWorks, newWork],
+      })),
+    deleteSelectedWork: (workId: string) =>
+      set((state) => ({
+        selectedWorks: state.selectedWorks.filter((work) => work.id !== workId),
+      })),
+    selectAllCurrentPageWorks: (clickedAll: boolean) => {
+      const { post, selectedWorks, page } = get();
+      const startIndex = (page - 1) * POST_LIST_PAGE_LIMIT;
+      const endIndex = startIndex + POST_LIST_PAGE_LIMIT;
+      const currentWorks = post?.works.slice(startIndex, endIndex) || [];
+      let newSelectedWorks = [...selectedWorks];
+
+      if (!clickedAll) {
+        currentWorks.forEach((work) => {
+          if (!newSelectedWorks.some((selectedWork) => selectedWork.id === work.id)) {
+            newSelectedWorks.push(work);
+          }
+        });
+      } else {
+        newSelectedWorks = selectedWorks.filter(
+          (selectedWork) => !currentWorks.some((work) => work.id === selectedWork.id)
+        );
+      }
+
+      set({ selectedWorks: newSelectedWorks });
+    },
+    setPage: (page: number) => set(() => ({ page })),
   }));
 };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -14,3 +14,5 @@ export const TARGET_BUTTONS: Array<{ value: TargetType; text: string }> = [
 ];
 
 export const MAIN_DATA_LIMIT = '14';
+
+export const POST_LIST_PAGE_LIMIT = 9;


### PR DESCRIPTION
1. post-store.ts와 post-store-provider.ts를 만들었습니다. 
2. /post/:postId 페이지에서 work 선택, 전체선택 기능을 zustand로 구현하였습니다. 

![selecte](https://github.com/Si-gongan/atag-admin-frontend/assets/131663155/d1c89ef7-2647-44f8-a762-828262486d38)


