### PR TITLE
Feat: /post/:postId에서 work 삭제기능 추가

### DIFF
--- a/src/components/post/DelExportButtons.tsx
+++ b/src/components/post/DelExportButtons.tsx
@@ -8,10 +8,11 @@ import { deleteWork } from '@/services/post';
 export default function DelExportButtons() {
   const [clickedAll, setClickedAll] = useState(false);
 
-  const { postId, selectedWorks, selectAllCurrentPageWorks, fetchPost } = usePostStore((state) => ({
+  const { postId, selectedWorks, selectAllCurrentPageWorks, resetSelectedWork, fetchPost } = usePostStore((state) => ({
     postId: state.postId,
     selectedWorks: state.selectedWorks,
     selectAllCurrentPageWorks: state.selectAllCurrentPageWorks,
+    resetSelectedWork: state.resetSelectedWork,
     fetchPost: state.fetchPost,
   }));
 
@@ -20,12 +21,13 @@ export default function DelExportButtons() {
     setClickedAll((prev) => !prev);
   };
 
-  const handleDelete = () => {
+  const handleDelete = async () => {
     if (selectedWorks.length === 0) return;
 
     const deleteIds = selectedWorks.map((work) => work.id);
-    deleteWork(postId, deleteIds);
-    fetchPost(postId);
+    await deleteWork(postId, deleteIds);
+    await fetchPost(postId);
+    resetSelectedWork();
   };
 
   const handleExport = () => {

--- a/src/services/post/index.ts
+++ b/src/services/post/index.ts
@@ -18,5 +18,5 @@ export async function deleteWork(postId: string, workIds: string[]) {
   };
 
   const response = await fetcher(requesrUrl, 'POST', option);
-  return response.result;
+  return response.result.post;
 }

--- a/src/stores/post-store.ts
+++ b/src/stores/post-store.ts
@@ -15,6 +15,7 @@ export type PostActionsType = {
   fetchPost: (postId: string) => Promise<void>;
   addSelectedWork: (newWork: WorksType) => void;
   deleteSelectedWork: (workId: string) => void;
+  resetSelectedWork: () => void;
   selectAllCurrentPageWorks: (clickedAll: boolean) => void;
   setPage: (page: number) => void;
 };
@@ -44,6 +45,7 @@ export const createPostStore = (initState: PostStateType = defaultPost) => {
       set((state) => ({
         selectedWorks: state.selectedWorks.filter((work) => work.id !== workId),
       })),
+    resetSelectedWork: () => set(() => ({ selectedWorks: [] })),
     selectAllCurrentPageWorks: (clickedAll: boolean) => {
       const { post, selectedWorks, page } = get();
       const startIndex = (page - 1) * POST_LIST_PAGE_LIMIT;


### PR DESCRIPTION
1. /post/:postId에서 선택한 work 삭제 기능을 추가했습니다. 




![delete](https://github.com/Si-gongan/atag-admin-frontend/assets/131663155/5c4e1494-1898-4781-9b92-c094445151bb)
