### PR TITLE
Feat: JSON, CSV, TXT 내보내기 기능 구현

### DIFF
--- a/src/components/common/DropdownLayout.tsx
+++ b/src/components/common/DropdownLayout.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+interface DropdownLayoutProps {
+  children: React.ReactNode;
+  position?: string;
+  onClose: () => void;
+}
+
+export default function DropdownLayout({ children, position, onClose }: DropdownLayoutProps) {
+  const outRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (outRef.current && !outRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+
+    document.addEventListener('click', handleClickOutside, true);
+    return () => {
+      document.removeEventListener('click', handleClickOutside, true);
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      ref={outRef}
+      className={`absolute flex flex-col items-center justify-center py-4 z-dropdown bg-white shadow-2xl border-1 border-gray-200 rounded-4 ${
+        position && position
+      }`}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/post/DelExportButtons.tsx
+++ b/src/components/post/DelExportButtons.tsx
@@ -4,9 +4,12 @@ import { useState } from 'react';
 import Button from '../common/Button';
 import { usePostStore } from '@/providers/post-store-provider';
 import { deleteWork } from '@/services/post';
+import ModalLayout from '../common/ModalLayout';
+import ExportDropdown from './ExportDropdown';
 
 export default function DelExportButtons() {
   const [clickedAll, setClickedAll] = useState(false);
+  const [exportDropdownOpen, setExportDropdownOpen] = useState(false);
 
   const { postId, selectedWorks, selectAllCurrentPageWorks, resetSelectedWork, fetchPost } = usePostStore((state) => ({
     postId: state.postId,
@@ -35,10 +38,11 @@ export default function DelExportButtons() {
   };
 
   return (
-    <div className="flex items-center gap-30">
+    <div className="relative flex items-center gap-30">
       <Button text="전체선택" size="large" clicked={clickedAll} selectable={true} onClick={handleSelectAll} />
       <Button text="삭제" size="large" onClick={handleDelete} />
-      <Button text="내보내기" size="large" onClick={handleExport} />
+      <Button text="내보내기" size="large" onClick={() => setExportDropdownOpen(true)} />
+      {exportDropdownOpen && <ExportDropdown onClose={() => setExportDropdownOpen(false)} />}
     </div>
   );
 }

--- a/src/components/post/ExportDropdown.tsx
+++ b/src/components/post/ExportDropdown.tsx
@@ -1,0 +1,30 @@
+import { EXPORT_FORMAT } from '@/utils/constants';
+import DropdownLayout from '../common/DropdownLayout';
+import exportData from '@/utils/exportData';
+import { usePostStore } from '@/providers/post-store-provider';
+
+interface ExportDropdownProps {
+  onClose: () => void;
+}
+
+export default function ExportDropdown({ onClose }: ExportDropdownProps) {
+  const { selectedWorks } = usePostStore((state) => ({ selectedWorks: state.selectedWorks }));
+
+  const handleClickExport = (type: string) => {
+    exportData(type, selectedWorks);
+    onClose();
+  };
+
+  return (
+    <DropdownLayout onClose={onClose} position="top-44 left-324">
+      {EXPORT_FORMAT.map((type) => (
+        <span
+          key={type}
+          className="flex items-center justify-center w-133 h-40 text-16 hover:font-bold"
+          onClick={() => handleClickExport(type)}>
+          {type}
+        </span>
+      ))}
+    </DropdownLayout>
+  );
+}

--- a/src/components/postIdEdit/EditContent.tsx
+++ b/src/components/postIdEdit/EditContent.tsx
@@ -33,12 +33,11 @@ export default function EditContent() {
   return (
     <div className="flex flex-col gap-28 w-full text-20">
       <div className="flex gap-25">
-        <div className="w-300 h-300 overflow-hidden">
+        <div className="relative w-300 h-300 overflow-hidden">
           <Image
             src={thumbnail}
             alt={`work ${editWork?.id}의 썸네일 이미지`}
-            width={300}
-            height={300}
+            fill
             sizes="50vw"
             style={{ objectFit: 'cover' }}
             placeholder="blur"

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -20,3 +20,11 @@ export const POST_LIST_PAGE_LIMIT = 9;
 export const TEXTAREA_LIMIT = {
   postIdEdit: 500,
 };
+
+export const EXPORT_FORMAT = ['CSV', 'JSON', 'TXT'];
+
+// export const EXPORT_SORT = [
+//   { id: 'csv', name: 'CSV' },
+//   { id: 'json', name: 'JSON' },
+//   { id: 'txt', name: 'TXT' },
+// ];

--- a/src/utils/exportData.ts
+++ b/src/utils/exportData.ts
@@ -1,0 +1,23 @@
+import { WorksType } from '@/services/post/schema';
+
+export default function exportData(exportFormat: string, selectedWorks: WorksType[]) {
+  const downloadData = [];
+  const headers = Object.keys(selectedWorks[0]).join(',');
+  downloadData.push(headers);
+
+  selectedWorks.forEach((work) => {
+    const values = Object.values(work).join(',');
+    downloadData.push(values);
+  });
+
+  const downloadContent = downloadData.join('\n');
+  const blob = new Blob([downloadContent], { type: `text/${exportFormat};charset=utf-8;` });
+
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.setAttribute('download', `ATAG ai 대체텍스트 의뢰 내용.${exportFormat}`);
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}


### PR DESCRIPTION
1. /post, /:postId에서 JSON, CSV, TXT로 내보내기(파일 다운로드) 기능을 구현했습니다. 


![다운](https://github.com/Si-gongan/atag-admin-frontend/assets/131663155/1640963b-e1a8-480e-832d-1dbe994affc4)
