### PR TITLE
Fix: main-store에 fetchDatas 추가하고 다른 컴포넌트에서 사용중인 fetch들 대체

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import './globals.css';
 
 export default async function MainPage() {
   const response = await getData({ target: 'all', state: 'all' });
+  // SEO
 
   return (
     <main className="w-1400 flex flex-col gap-60 mb-24">
@@ -15,8 +16,8 @@ export default async function MainPage() {
         <hr className="h-38 border-1" />
         <SortButtons type="target" buttons={TARGET_BUTTONS} />
       </section>
-      <ListSection data={response.data} />
-      <MainPagination initTotalPages={response.totalPages} />
+      <ListSection />
+      <MainPagination />
     </main>
   );
 }

--- a/src/components/main/ListSection.tsx
+++ b/src/components/main/ListSection.tsx
@@ -1,29 +1,24 @@
 'use client';
 
-import { DataType } from '@/services/main/schema';
 import ListItem from './ListItem';
 import { useMainStore } from '@/providers/main-store-provider';
 import { useEffect } from 'react';
 import Link from 'next/link';
 import { URL_PATH } from '@/utils/route';
 
-interface ListSectionProps {
-  data: DataType[];
-}
-
-export default function ListSection({ data }: ListSectionProps) {
-  const { datas, setDatas } = useMainStore((state) => state);
+export default function ListSection() {
+  const { datas, fetchDatas } = useMainStore((state) => ({ datas: state.datas, fetchDatas: state.fetchDatas }));
 
   useEffect(() => {
-    setDatas(data);
-  }, [data, setDatas]);
+    fetchDatas();
+  }, [fetchDatas]);
 
   return (
     <section className="flex flex-wrap gap-y-37 gap-x-66">
       <div className="flex items-center justify-center w-224 h-245 rounded-lg bg-gray-300 text-24 text-white">
         + 새 의뢰 생성
       </div>
-      {datas.map((item) => {
+      {datas?.map((item) => {
         const linkHref = item.target === undefined ? URL_PATH.INSPECT_DETAIL(item.id) : URL_PATH.POST_DETAIL(item.id);
 
         return (

--- a/src/components/main/MainPagination.tsx
+++ b/src/components/main/MainPagination.tsx
@@ -1,31 +1,20 @@
 'use client';
 
 import { useMainStore } from '@/providers/main-store-provider';
-import { getData } from '@/services/main';
-import { StateType } from '@/services/main/schema';
-import { useCallback, useEffect } from 'react';
+import { useEffect } from 'react';
 import Pagination from '../common/Pagination';
 
-interface MainPaginationProps {
-  initTotalPages: number;
-}
-
-export default function MainPagination({ initTotalPages }: MainPaginationProps) {
-  const { page, setPage, totalPages, setTotalPages, setDatas, state } = useMainStore((state) => state);
-
-  const fetchPageData = useCallback(async () => {
-    const response = await getData({ target: 'all', state: state as StateType, page: String(page) });
-
-    setDatas(response.data);
-  }, [state, setDatas, page]);
+export default function MainPagination() {
+  const { page, setPage, totalPages, fetchDatas } = useMainStore((state) => ({
+    page: state.page,
+    setPage: state.setPage,
+    totalPages: state.totalPages,
+    fetchDatas: state.fetchDatas,
+  }));
 
   useEffect(() => {
-    setTotalPages(initTotalPages);
-  }, [initTotalPages, setTotalPages]);
-
-  useEffect(() => {
-    fetchPageData();
-  }, [page, fetchPageData]);
+    fetchDatas();
+  }, [page, fetchDatas]);
 
   return <Pagination page={page} setPage={setPage} totalPages={totalPages} />;
 }

--- a/src/components/main/SortButtons.tsx
+++ b/src/components/main/SortButtons.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { useMainStore } from '@/providers/main-store-provider';
-import { getData } from '@/services/main';
-import { useCallback, useEffect } from 'react';
+import { useEffect } from 'react';
 import { StateType, TargetType } from '@/services/main/schema';
 import Button from '../common/Button';
 
@@ -12,28 +11,28 @@ interface SortButtonsProps<T> {
 }
 
 export default function SortButtons<T extends StateType | TargetType>({ type, buttons }: SortButtonsProps<T>) {
-  const { state, setState, target, setTarget, setDatas, setPage, setTotalPages } = useMainStore((state) => state);
+  const { state, setState, target, setTarget, setPage, fetchDatas } = useMainStore((state) => ({
+    state: state.state,
+    setState: state.setState,
+    target: state.target,
+    setTarget: state.setTarget,
+    setPage: state.setPage,
+    fetchDatas: state.fetchDatas,
+  }));
 
   const currentValue = type === 'state' ? state : target;
-
-  const fetchMainData = useCallback(async () => {
-    const response = await getData({ target, state });
-
-    setDatas(response.data);
-    setTotalPages(response.totalPages);
-  }, [setDatas, setTotalPages, state, target]);
 
   const handleChange = (value: T) => {
     setPage(1);
 
     if (type === 'state') {
       setState(value as StateType);
-    } else if (type === 'target') setTarget(value as TargetType);
+      fetchDatas();
+    } else if (type === 'target') {
+      setTarget(value as TargetType);
+      fetchDatas();
+    }
   };
-
-  useEffect(() => {
-    fetchMainData();
-  }, [state, target, fetchMainData]);
 
   return (
     <div className="flex items-center gap-40">

--- a/src/services/main/index.ts
+++ b/src/services/main/index.ts
@@ -14,13 +14,6 @@ export async function getData(params: getDataParamsType) {
 
   if (params.search) requestParams.set('search', params.search);
 
-  // const optionalParams = ['search'];
-  // optionalParams.forEach((param) => {
-  //   if (params[param]) {
-  //     requestParams.set(param, params[param] as string);
-  //   }
-  // });
-
   const requestUrl = `${API_ROUTE.GET_DATA(requestParams.toString())}`;
 
   const response = await fetcher(requestUrl, 'GET');

--- a/src/stores/main-store.ts
+++ b/src/stores/main-store.ts
@@ -1,5 +1,6 @@
 import { createStore } from 'zustand/vanilla';
-import { DataType, StateType, TargetType } from '@/services/main/schema';
+import { DataType, StateType, TargetType, getDataParamsType } from '@/services/main/schema';
+import { getData } from '@/services/main';
 
 export type MainStateType = {
   datas: DataType[];
@@ -17,6 +18,7 @@ export type MainActionsType = {
   setPage: (page: number) => void;
   setTotalPages: (totalPages: number) => void;
   setSearch: (search: string) => void;
+  fetchDatas: () => Promise<void>;
 };
 
 export type CreateMainStoreType = MainStateType & MainActionsType;
@@ -31,7 +33,7 @@ export const defaultData: MainStateType = {
 };
 
 export const createMainStore = (initState: MainStateType = defaultData) => {
-  return createStore<CreateMainStoreType>()((set) => ({
+  return createStore<CreateMainStoreType>()((set, get) => ({
     ...initState,
     setDatas: (datas: DataType[]) => set(() => ({ datas })),
     setTarget: (target: TargetType) => set(() => ({ target })),
@@ -39,5 +41,10 @@ export const createMainStore = (initState: MainStateType = defaultData) => {
     setPage: (page: number) => set(() => ({ page })),
     setTotalPages: (totalPages: number) => set(() => ({ totalPages })),
     setSearch: (search: string) => set(() => ({ search })),
+    fetchDatas: async () => {
+      const { target, state, page } = get();
+      const response = await getData({ target, state, page: page.toString() });
+      set({ datas: response.data, totalPages: response.totalPages });
+    },
   }));
 };


### PR DESCRIPTION
1. main페이지의 각 컴포넌트들 안에서 상태값이 바뀔때마다 fetch 함수를 따로 줘서 작동시켰는데 main-store에 fetchDatas 만들어서 재사용하였습니다. 
